### PR TITLE
Add default google engine and Android 11 intent.

### DIFF
--- a/demo/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/demo/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -18,6 +18,12 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>
 
+	<queries>
+		<intent>
+			<action android:name="android.intent.action.TTS_SERVICE" />
+		</intent>
+	</queries>
+
 	<application
 		android:name="com.tns.NativeScriptApplication"
 		android:allowBackup="true"

--- a/src/texttospeech.android.ts
+++ b/src/texttospeech.android.ts
@@ -41,7 +41,8 @@ export class TNSTextToSpeech {
                                 reject(new Error('TextToSpeech failed to init with code ' + status));
                             }
                         },
-                    })
+                    }),
+                    "com.google.android.tts"
                 );
             });
         }


### PR DESCRIPTION
Some mobile phone brands, for example samsung, bring their native tts engine and not google's. Often with some flaws in terms of quantity and quality in the languages/locale.

I came across this problem when the pt-PT locale and the samsung phone had its own default engine on the device and it gave a null response. The google engine must be used to have access to all the languages ​​present in the documentation.

Also faced faced some compatibility problems related with the last android version:

Apps targeting Android 11 that use text-to-speech should declare [TextToSpeech.Engine.INTENT_ACTION_TTS_SERVICE](https://developer.android.com/reference/android/speech/tts/TextToSpeech.Engine#INTENT_ACTION_TTS_SERVICE) in the queries elements of their manifest.